### PR TITLE
Import ShieldOID to fix test

### DIFF
--- a/Tests/CertificationRequestBuilderTests.swift
+++ b/Tests/CertificationRequestBuilderTests.swift
@@ -9,6 +9,7 @@
 //
 
 import PotentASN1
+import ShieldOID
 @testable import Shield
 import XCTest
 


### PR DESCRIPTION
Fixes #8 

Importing ShieldOID appears to then allow 

```make```

To complete successfully.
