### PR TITLE
Fix ASN.1 AlgorithmIdentifier parsing if it has no optional parameters field

### DIFF
--- a/Sources/ShieldX509/AlgorithmIdentifier.swift
+++ b/Sources/ShieldX509/AlgorithmIdentifier.swift
@@ -21,6 +21,12 @@ public struct AlgorithmIdentifier: Equatable, Hashable, Codable {
     self.algorithm = algorithm
     self.parameters = parameters
   }
+    
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    algorithm = try container.decode(ObjectIdentifier.self, forKey: .algorithm)
+    parameters = try container.decodeIfPresent(ASN1.self, forKey: .parameters) ?? .null
+  }
 
 }
 


### PR DESCRIPTION
Fix for #22.
Thanks!
 