### PR TITLE
Fix ECDA signature parsing and encoding

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/outfoxx/PotentCodables.git",
         "state": {
           "branch": null,
-          "revision": "40c495797fbc2f1f8a6becb89c9058cdfce0732e",
-          "version": "2.0.1"
+          "revision": "c3f5c13aae9de60d1834901ba641034daf86f058",
+          "version": "2.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
       targets: ["Shield", "ShieldSecurity", "ShieldCrypto", "ShieldOID", "ShieldPKCS", "ShieldX509", "ShieldX500"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/outfoxx/PotentCodables.git", from: "2.0.1"),
+    .package(url: "https://github.com/outfoxx/PotentCodables.git", from: "2.1.0"),
     .package(url: "https://github.com/sharplet/Regex.git", from: "2.1.0")
   ],
   targets: [

--- a/Sources/ShieldSecurity/AlgorithmIdentifier.swift
+++ b/Sources/ShieldSecurity/AlgorithmIdentifier.swift
@@ -61,13 +61,13 @@ public extension AlgorithmIdentifier {
       }
     }
 
-    self.init(algorithm: signingAlgorithmID)
+    self.init(algorithm: signingAlgorithmID, parameters: nil)
   }
 
   init(publicKey: SecKey) throws {
     switch try publicKey.keyType() {
     case .rsa:
-      self.init(algorithm: iso.memberBody.us.rsadsi.pkcs.pkcs1.rsaEncryption.oid)
+      self.init(algorithm: iso.memberBody.us.rsadsi.pkcs.pkcs1.rsaEncryption.oid, parameters: nil)
 
     case .ec:
       let curve: OID

--- a/Sources/ShieldX509/AlgorithmIdentifier.swift
+++ b/Sources/ShieldX509/AlgorithmIdentifier.swift
@@ -15,9 +15,9 @@ import PotentASN1
 public struct AlgorithmIdentifier: Equatable, Hashable, Codable {
 
   public var algorithm: ObjectIdentifier
-  public var parameters: ASN1
+  public var parameters: ASN1?
 
-  public init(algorithm: ObjectIdentifier, parameters: ASN1 = .null) {
+  public init(algorithm: ObjectIdentifier, parameters: ASN1? = nil) {
     self.algorithm = algorithm
     self.parameters = parameters
   }

--- a/Sources/ShieldX509/TBSCertificate.swift
+++ b/Sources/ShieldX509/TBSCertificate.swift
@@ -103,6 +103,11 @@ public extension Schemas {
     iso.memberBody.us.rsadsi.pkcs.pkcs1.sha256WithRSAEncryption.asn1: .optional(.null),
     iso.memberBody.us.rsadsi.pkcs.pkcs1.sha384WithRSAEncryption.asn1: .optional(.null),
     iso.memberBody.us.rsadsi.pkcs.pkcs1.sha512WithRSAEncryption.asn1: .optional(.null),
+    iso.memberBody.us.ansix962.signatures.ecdsaWithSHA1.asn1: .null,
+    iso.memberBody.us.ansix962.signatures.ecdsaWithSHA2.ecdsaWithSHA224.asn1: .nothing,
+    iso.memberBody.us.ansix962.signatures.ecdsaWithSHA2.ecdsaWithSHA256.asn1: .nothing,
+    iso.memberBody.us.ansix962.signatures.ecdsaWithSHA2.ecdsaWithSHA384.asn1: .nothing,
+    iso.memberBody.us.ansix962.signatures.ecdsaWithSHA2.ecdsaWithSHA512.asn1: .nothing,
   ]
 
   static let TBSCertificate: Schema =


### PR DESCRIPTION
* Adds schema mappings for ECDSA signature types
* `AlgorithmIdentifier.parameters` is now optional

Fixes #22 