### PR TITLE
Fixes to GeneralNames, and dependent types, encoding/decoding

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/outfoxx/PotentCodables.git",
         "state": {
           "branch": null,
-          "revision": "c3f5c13aae9de60d1834901ba641034daf86f058",
-          "version": "2.1.0"
+          "revision": "245b26409355b3889420803e362e6d09249d24c8",
+          "version": "2.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
       targets: ["Shield", "ShieldSecurity", "ShieldCrypto", "ShieldOID", "ShieldPKCS", "ShieldX509", "ShieldX500"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/outfoxx/PotentCodables.git", from: "2.1.0"),
+    .package(url: "https://github.com/outfoxx/PotentCodables.git", from: "2.3.0"),
     .package(url: "https://github.com/sharplet/Regex.git", from: "2.1.0")
   ],
   targets: [

--- a/Sources/ShieldX509/EDIPartyName.swift
+++ b/Sources/ShieldX509/EDIPartyName.swift
@@ -14,8 +14,13 @@ import ShieldX500
 
 
 public struct EDIPartyName: Equatable, Hashable, Codable {
-  public var nameAssigner: DirectoryName?
-  public var partyName: DirectoryName
+  public var nameAssigner: AnyString?
+  public var partyName: AnyString
+
+  public init(nameAssigner: AnyString? = nil, partyName: AnyString) {
+    self.nameAssigner = nameAssigner
+    self.partyName = partyName
+  }
 }
 
 
@@ -26,8 +31,8 @@ public extension Schemas {
 
   static let EDIPartyName: Schema =
     .sequence([
-      "nameAssigner": .implicit(0, .optional(directoryString())),
-      "value": .implicit(1, directoryString()),
+      "nameAssigner": .explicit(0, .optional(directoryString())),
+      "partyName": .explicit(1, directoryString()),
     ])
 
 }

--- a/Sources/ShieldX509/GeneralName.swift
+++ b/Sources/ShieldX509/GeneralName.swift
@@ -29,8 +29,13 @@ public enum GeneralName: Equatable, Hashable, TaggedValue {
   public init?(tag: ASN1.AnyTag, value: Any?) {
     switch ASN1.Tag.value(from: tag, in: .contextSpecific) {
     case 0:
-      guard let value = value as? OtherName else { return nil }
-      self = .otherName(value)
+      guard
+        let values = value as? [ASN1],
+        let name = try? ASN1Decoder(schema: Schemas.OtherName).decodeTree(OtherName.self, from: .sequence(values))
+      else {
+        return nil
+      }
+      self = .otherName(name)
     case 1:
       guard let value = value as? AnyString else { return nil }
       self = .rfc822Name(value.storage)
@@ -41,11 +46,21 @@ public enum GeneralName: Equatable, Hashable, TaggedValue {
       guard let value = value as? ASN1 else { return nil }
       self = .x400Address(value)
     case 4:
-      guard let value = value as? Name else { return nil }
-      self = .directoryName(value)
+      guard
+        let values = value as? [ASN1],
+        let name = try? ASN1Decoder(schema: Schemas.Name).decodeTree(Name.self, from: .sequence(values))
+      else {
+        return nil
+      }
+      self = .directoryName(name)
     case 5:
-      guard let value = value as? EDIPartyName else { return nil }
-      self = .ediPartyName(value)
+      guard
+        let values = value as? [ASN1],
+        let name = try? ASN1Decoder(schema: Schemas.EDIPartyName).decodeTree(EDIPartyName.self, from: .sequence(values))
+      else {
+        return nil
+      }
+      self = .ediPartyName(name)
     case 6:
       guard let value = value as? AnyString else { return nil }
       self = .uniformResourceIdentifier(value.storage)
@@ -60,17 +75,46 @@ public enum GeneralName: Equatable, Hashable, TaggedValue {
     }
   }
 
-  public var tagAndValue: (ASN1.AnyTag, Any?) {
+  public var tag: ASN1.AnyTag {
     switch self {
-    case .otherName(let value): return (0, value)
-    case .rfc822Name(let value): return (1, value)
-    case .dnsName(let value): return (2, value)
-    case .x400Address(let value): return (3, value)
-    case .directoryName(let value): return (4, value)
-    case .ediPartyName(let value): return (5, value)
-    case .uniformResourceIdentifier(let value): return (6, value)
-    case .ipAddress(let value): return (7, value)
-    case .registeredID(let value): return (8, value)
+    case .otherName: return 0
+    case .rfc822Name: return 1
+    case .dnsName: return 2
+    case .x400Address: return 3
+    case .directoryName: return 4
+    case .ediPartyName: return 5
+    case .uniformResourceIdentifier: return 6
+    case .ipAddress: return 7
+    case .registeredID: return 8
+    }
+  }
+
+  public var value: Any? {
+    switch self {
+    case .otherName(let value): return value
+    case .rfc822Name(let value): return value
+    case .dnsName(let value): return value
+    case .x400Address(let value): return value
+    case .directoryName(let value): return value
+    case .ediPartyName(let value): return value
+    case .uniformResourceIdentifier(let value): return value
+    case .ipAddress(let value): return value
+    case .registeredID(let value): return value
+    }
+  }
+
+  public func encode(schema: Schema) throws -> ASN1 {
+    let encoder = ASN1Encoder(schema: schema)
+    switch self {
+    case .otherName(let value): return try encoder.encodeTree(value)
+    case .rfc822Name(let value): return try encoder.encodeTree(value)
+    case .dnsName(let value): return try encoder.encodeTree(value)
+    case .x400Address(let value): return value
+    case .directoryName(let value): return try encoder.encodeTree(value)
+    case .ediPartyName(let value): return try encoder.encodeTree(value)
+    case .uniformResourceIdentifier(let value): return try encoder.encodeTree(value)
+    case .ipAddress(let value): return try encoder.encodeTree(value)
+    case .registeredID(let value): return try encoder.encodeTree(value)
     }
   }
 }
@@ -90,7 +134,7 @@ public extension Schemas {
       .implicit(1, .string(kind: .ia5)),
       .implicit(2, .string(kind: .ia5)),
       .implicit(3, .any),
-      .implicit(4, Name),
+      .explicit(4, Name),
       .implicit(5, EDIPartyName),
       .implicit(6, .string(kind: .ia5)),
       .implicit(7, .octetString()),
@@ -178,4 +222,13 @@ extension GeneralName: Codable {
     }
   }
 
+}
+
+private func encodeToSequence<T: Encodable>(_ value: T, using schema: Schema) throws -> [ASN1]? {
+  return try ASN1Encoder(schema: schema).encodeTree(value).sequenceValue
+}
+
+private func decodeFromSequence<T: Decodable>(_ type: T.Type, from value: Any?, using schema: Schema) -> T? {
+  guard let values = value as? [ASN1] else { return nil }
+  return try? ASN1Decoder(schema: schema).decodeTree(type, from: .sequence(values))
 }

--- a/Sources/ShieldX509/OtherName.swift
+++ b/Sources/ShieldX509/OtherName.swift
@@ -15,6 +15,33 @@ import PotentASN1
 public struct OtherName: Equatable, Hashable, Codable {
   public var typeId: ObjectIdentifier
   public var value: ASN1
+
+  public init(typeId: ObjectIdentifier, value: ASN1) {
+    self.typeId = typeId
+    self.value = value
+  }
+
+  enum CodingKeys: CodingKey {
+    case typeId
+    case value
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.typeId = try container.decode(ObjectIdentifier.self, forKey: .typeId)
+    let value = try container.decode(ASN1.self, forKey: .value)
+    guard case let ASN1.tagged(_, data) = value else {
+      throw DecodingError.dataCorruptedError(forKey: .value, in: container, debugDescription: "Expected tagged value")
+    }
+    self.value = try DERReader.parse(data: data).first ?? .null
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(typeId, forKey: .typeId)
+    try container.encode(ASN1.tagged(ASN1.Tag.tag(from: 0, in: .contextSpecific, constructed: true), DERWriter.write(value)), forKey: .value)
+  }
+
 }
 
 


### PR DESCRIPTION
Fixes #36, #37

Complex GeneralNames were previously encoded incorrectly. The encoding/decoding is fixed and now OpenSSL verification is added to the tests to ensure structures match.