### PR TITLE
Update to PotentCodables 3.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/outfoxx/PotentCodables.git",
         "state": {
           "branch": null,
-          "revision": "236dad82f4e1e1e5cf2e482da7d3c0def51c2cde",
-          "version": "2.4.2"
+          "revision": "176c788bc0504af340adcf81c6106d7a2847d436",
+          "version": "3.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
       targets: ["Shield", "ShieldSecurity", "ShieldCrypto", "ShieldOID", "ShieldPKCS", "ShieldX509", "ShieldX500"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/outfoxx/PotentCodables.git", from: "2.4.2"),
-    .package(url: "https://github.com/sharplet/Regex.git", from: "2.1.0")
+    .package(url: "https://github.com/outfoxx/PotentCodables.git", from: "3.0.0"),
+    .package(url: "https://github.com/sharplet/Regex.git", from: "2.1.0"),
   ],
   targets: [
     .target(

--- a/Sources/ShieldSecurity/Certificate.swift
+++ b/Sources/ShieldSecurity/Certificate.swift
@@ -19,7 +19,7 @@ public extension Certificate.Builder {
 
   func publicKey(keyPair: SecKeyPair, usage keyUsage: KeyUsage? = nil) throws -> Certificate.Builder {
     return try publicKey(
-      keyPair.encodedPublicKey(),
+      BitString(bytes: keyPair.encodedPublicKey()),
       algorithm: .init(publicKey: keyPair.publicKey),
       usage: keyUsage
     )
@@ -27,7 +27,7 @@ public extension Certificate.Builder {
 
   func publicKey(publicKey: SecKey, usage keyUsage: KeyUsage? = nil) throws -> Certificate.Builder {
     return try self.publicKey(
-      publicKey.encode(),
+      BitString(bytes: publicKey.encode()),
       algorithm: .init(publicKey: publicKey),
       usage: keyUsage
     )
@@ -41,7 +41,9 @@ public extension Certificate.Builder {
 
     let signature = try signingKey.sign(data: tbsCertificate.encoded(), digestAlgorithm: digestAlgorithm)
 
-    return Certificate(tbsCertificate: tbsCertificate, signatureAlgorithm: signatureAlgorithm, signature: signature)
+    return Certificate(tbsCertificate: tbsCertificate,
+                       signatureAlgorithm: signatureAlgorithm,
+                       signature: BitString(bytes: signature))
   }
 
 }

--- a/Sources/ShieldSecurity/CertificationRequest.swift
+++ b/Sources/ShieldSecurity/CertificationRequest.swift
@@ -18,7 +18,7 @@ public extension CertificationRequest.Builder {
 
   func publicKey(keyPair: SecKeyPair, usage keyUsage: KeyUsage? = nil) throws -> CertificationRequest.Builder {
     return try publicKey(
-      keyPair.encodedPublicKey(),
+      BitString(bytes: keyPair.encodedPublicKey()),
       algorithm: .init(publicKey: keyPair.publicKey),
       usage: keyUsage
     )
@@ -26,7 +26,7 @@ public extension CertificationRequest.Builder {
 
   func publicKey(publicKey: SecKey, usage keyUsage: KeyUsage? = nil) throws -> CertificationRequest.Builder {
     return try self.publicKey(
-      publicKey.encode(),
+      BitString(bytes: publicKey.encode()),
       algorithm: .init(publicKey: publicKey),
       usage: keyUsage
     )

--- a/Sources/ShieldSecurity/SecKeyPair.swift
+++ b/Sources/ShieldSecurity/SecKeyPair.swift
@@ -281,8 +281,8 @@ extension SecKeyPair: Codable {
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: Self.CodingKeys.self)
-    privateKey = try SecKey.load(persistentReference: container.decode(Data.self, forKey: .private))
-    publicKey = try SecKey.load(persistentReference: container.decode(Data.self, forKey: .public))
+    try self.init(privateKeyRef: container.decode(Data.self, forKey: .private),
+                  publicKeyRef: container.decode(Data.self, forKey: .public))
   }
 
   public func encode(to encoder: Encoder) throws {

--- a/Sources/ShieldX509/Certificate.swift
+++ b/Sources/ShieldX509/Certificate.swift
@@ -17,9 +17,9 @@ public struct Certificate: Equatable, Hashable, Codable {
 
   public var tbsCertificate: TBSCertificate
   public var signatureAlgorithm: AlgorithmIdentifier
-  public var signature: Data
+  public var signature: BitString
 
-  public init(tbsCertificate: TBSCertificate, signatureAlgorithm: AlgorithmIdentifier, signature: Data) {
+  public init(tbsCertificate: TBSCertificate, signatureAlgorithm: AlgorithmIdentifier, signature: BitString) {
     self.tbsCertificate = tbsCertificate
     self.signatureAlgorithm = signatureAlgorithm
     self.signature = signature

--- a/Sources/ShieldX509/CertificateBuilder.swift
+++ b/Sources/ShieldX509/CertificateBuilder.swift
@@ -230,7 +230,7 @@ public extension Certificate {
     }
 
     public func publicKey(
-      _ publicKey: Data,
+      _ publicKey: BitString,
       algorithm: AlgorithmIdentifier,
       usage keyUsage: KeyUsage? = nil
     ) throws -> Builder {
@@ -272,7 +272,7 @@ public extension Certificate {
         throw Error.missingParameter("subjectPublicKeyInfo.subjectPublicKey")
       }
 
-      let keyIdentifier = Digester.digest(subjectPublicKey, using: .sha1)
+      let keyIdentifier = Digester.digest(subjectPublicKey.bytes, using: .sha1)
 
       return try subjectKeyIdentifier(keyIdentifier)
     }
@@ -435,7 +435,7 @@ public extension Certificate {
     public static func randomSerialNumber() throws -> ASN1.Integer {
       var data = (0 ..< 20).map { _ in UInt8.random(in: 0 ... UInt8.max) } // max is 20 octets
       data[0] &= 0x7F // must be non-negative
-      return ASN1.Integer(serialized: Data(data))
+      return ASN1.Integer(derEncoded: Data(data))
     }
 
   }

--- a/Sources/ShieldX509/CertificationRequestBuilder.swift
+++ b/Sources/ShieldX509/CertificationRequestBuilder.swift
@@ -68,7 +68,7 @@ public extension CertificationRequest {
     }
 
     public func publicKey(
-      _ publicKey: Data,
+      _ publicKey: BitString,
       algorithm: AlgorithmIdentifier,
       usage keyUsage: KeyUsage? = nil
     ) throws -> Builder {

--- a/Sources/ShieldX509/OtherName.swift
+++ b/Sources/ShieldX509/OtherName.swift
@@ -33,13 +33,14 @@ public struct OtherName: Equatable, Hashable, Codable {
     guard case let ASN1.tagged(_, data) = value else {
       throw DecodingError.dataCorruptedError(forKey: .value, in: container, debugDescription: "Expected tagged value")
     }
-    self.value = try ASN1DERReader.parse(data: data).first ?? .null
+    self.value = try ASN1Serialization.asn1(fromDER: data).first ?? .null
   }
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(typeId, forKey: .typeId)
-    try container.encode(ASN1.tagged(ASN1.Tag.tag(from: 0, in: .contextSpecific, constructed: true), ASN1DERWriter.write(value)), forKey: .value)
+    try container.encode(ASN1.tagged(ASN1.Tag.tag(from: 0, in: .contextSpecific, constructed: true),
+                                     ASN1Serialization.der(from: value)), forKey: .value)
   }
 
 }

--- a/Sources/ShieldX509/SubjectPublicKeyInfo.swift
+++ b/Sources/ShieldX509/SubjectPublicKeyInfo.swift
@@ -15,9 +15,9 @@ import PotentASN1
 public struct SubjectPublicKeyInfo: Equatable, Hashable, Codable {
 
   public var algorithm: AlgorithmIdentifier
-  public var subjectPublicKey: Data
+  public var subjectPublicKey: BitString
 
-  public init(algorithm: AlgorithmIdentifier, subjectPublicKey: Data) {
+  public init(algorithm: AlgorithmIdentifier, subjectPublicKey: BitString) {
     self.algorithm = algorithm
     self.subjectPublicKey = subjectPublicKey
   }

--- a/Tests/SecKeyPairTests.swift
+++ b/Tests/SecKeyPairTests.swift
@@ -95,6 +95,19 @@ class SecKeyPairTests: XCTestCase {
 
   }
 
+  func testCodable() throws {
+
+    let rsaData = try JSONEncoder().encode(rsaKeyPair)
+    let testRSAKeyPair = try JSONDecoder().decode(SecKeyPair.self, from: rsaData)
+    XCTAssertEqual(testRSAKeyPair.privateKey, rsaKeyPair.privateKey)
+    XCTAssertEqual(testRSAKeyPair.publicKey, rsaKeyPair.publicKey)
+
+    let ecData = try JSONEncoder().encode(ecKeyPair)
+    let testECKeyPair = try JSONDecoder().decode(SecKeyPair.self, from: ecData)
+    XCTAssertEqual(testECKeyPair.privateKey, ecKeyPair.privateKey)
+    XCTAssertEqual(testECKeyPair.publicKey, ecKeyPair.publicKey)
+  }
+
   func testGenerateSecureEnclave() throws {
     try XCTSkipIf(true, "Only runs on iPhone/iPad/AppleTV or a Mac with T2")
 


### PR DESCRIPTION
This required API changes for `BIT STRING` types. Previously PotentCodables treated `BitString` and `Data` interchangably. The new version requires matching the types so Shield now uses `BitString` whenever a ASN.1 `BIT STRING` is specified.