### PR TITLE
Remove unused error cases in SecKeyPair

### DIFF
--- a/Sources/ShieldSecurity/SecKeyPair.swift
+++ b/Sources/ShieldSecurity/SecKeyPair.swift
@@ -36,9 +36,6 @@ public struct SecKeyPair {
   public enum Error: Int, Swift.Error {
     case generateFailed
     case failedToCopyPublicKeyFromPrivateKey
-    case noMatchingKey
-    case itemAddFailed
-    case itemDeleteFailed
 
     public static func build(error: Error, message: String, status: OSStatus) -> NSError {
       let error = error as NSError


### PR DESCRIPTION
Remove unused error cases noMatchingKey, itemAddFailed and itemDeleteFailed.

This commit removes them... since they don't appear to be used. However I wonder if it's better to @available deprecate them and remove them in the next major version?