### PR TITLE
Use CryptoKit to derive the EC public key during PKCS8 import

### DIFF
--- a/Sources/ShieldSecurity/AlgorithmIdentifier.swift
+++ b/Sources/ShieldSecurity/AlgorithmIdentifier.swift
@@ -19,6 +19,7 @@ public extension AlgorithmIdentifier {
 
   enum Error: Swift.Error {
     case unsupportedAlgorithm
+    @available(*, deprecated, message: "No longer used")
     case unsupportedECKeySize
   }
 
@@ -81,7 +82,7 @@ public extension AlgorithmIdentifier {
         // P-521, secp521r1
         curve = iso.org.certicom.curve.ansip521r1.oid
       default:
-        throw Error.unsupportedECKeySize
+        throw Error.unsupportedAlgorithm
       }
 
       self.init(

--- a/Tests/SecKeyPairTests.swift
+++ b/Tests/SecKeyPairTests.swift
@@ -213,11 +213,46 @@ class SecKeyPairTests: XCTestCase {
     XCTAssertThrowsError(try SecKeyPair.import(fromData: exportedKeyData, withPassword: "456"))
   }
 
-  func testImportExportEC() throws {
+  func testImportExportEC192() throws {
 
-    let exportedKeyData = try ecKeyPair.export()
+    let ecKeyPair =
+      try SecKeyPair.Builder(type: .ec, keySize: 192)
+        .generate(label: "Test 192 EC Key")
+    defer { try? ecKeyPair.delete() }
 
-    _ = try SecKeyPair.import(fromData: exportedKeyData)
+    XCTAssertThrowsError(try SecKeyPair.import(fromData: ecKeyPair.export())) { error in
+      XCTAssertTrue(error is AlgorithmIdentifier.Error)
+    }
+  }
+
+  func testImportExportEC256() throws {
+
+    let ecKeyPair =
+      try SecKeyPair.Builder(type: .ec, keySize: 256)
+        .generate(label: "Test 256 EC Key")
+    defer { try? ecKeyPair.delete() }
+
+    _ = try SecKeyPair.import(fromData: ecKeyPair.export())
+  }
+
+  func testImportExportEC384() throws {
+
+    let ecKeyPair =
+      try SecKeyPair.Builder(type: .ec, keySize: 384)
+        .generate(label: "Test 384 EC Key")
+    defer { try? ecKeyPair.delete() }
+
+    _ = try SecKeyPair.import(fromData: ecKeyPair.export())
+  }
+
+  func testImportExportEC521() throws {
+
+    let ecKeyPair =
+      try SecKeyPair.Builder(type: .ec, keySize: 521)
+        .generate(label: "Test 521 EC Key")
+    defer { try? ecKeyPair.delete() }
+
+    _ = try SecKeyPair.import(fromData: ecKeyPair.export())
   }
 
   func testCodable() throws {


### PR DESCRIPTION
This ensures the PKCS8 import works when encoded without the optional public key point, since the full public key point and private key are required for `SecKeyCreateWithData`.