### PR TITLE
Rename import & decode methods that use ObjC style naming

### DIFF
--- a/Sources/ShieldSecurity/SecKey.swift
+++ b/Sources/ShieldSecurity/SecKey.swift
@@ -93,7 +93,12 @@ public extension SecKey {
     return ref as! SecKey // swiftlint:disable:this force_cast
   }
 
+  @available(*, deprecated, message: "Use decode(data:type:class:) insead")
   static func decode(fromData data: Data, type: CFString, class keyClass: CFString) throws -> SecKey {
+    return try decode(data: data, type: type, class: keyClass)
+  }
+
+  static func decode(data: Data, type: CFString, class keyClass: CFString) throws -> SecKey {
 
     let attrs = [
       kSecClass as String: kSecClassKey,

--- a/Sources/ShieldSecurity/SecKeyPair.swift
+++ b/Sources/ShieldSecurity/SecKeyPair.swift
@@ -203,7 +203,7 @@ public struct SecKeyPair {
   public init(type: SecKeyType, privateKeyData: Data) throws {
 
     privateKey = try SecKey.decode(
-      fromData: privateKeyData,
+      data: privateKeyData,
       type: type.systemValue,
       class: kSecAttrKeyClassPrivate
     )
@@ -321,7 +321,7 @@ public struct SecKeyPair {
   /// Encodes the key pair's private key in PKCS#8 format and then encrypts it using PBKDF and packages
   /// into PKCS#8 encrypted format.
   ///
-  /// With the exported key and original password, ``import(fromData:withPassword:)``
+  /// With the exported key and original password, ``import(data:password:)``
   /// can be used to recover the original `SecKey`.
   ///
   /// - Parameters:
@@ -394,7 +394,7 @@ public struct SecKeyPair {
 
   /// Encodes the key pair's private key in PKCS#8 format.
   ///
-  /// With the exported key and original password, ``import(fromData:withPassword:)``
+  /// With the exported key and original password, ``import(data:password:)``
   /// can be used to recover the original `SecKey`.
   ///
   /// - Returns: Encoded encrypted key and PBKDF paraemters.
@@ -415,7 +415,23 @@ public struct SecKeyPair {
   ///   - password: Password used during key export.
   /// - Returns: ``SecKeyPair`` for the decrypted & decoded private key.
   ///
+  @available(*, deprecated, message: "Use import(data:password:) instead")
   public static func `import`(fromData data: Data, withPassword password: String) throws -> SecKeyPair {
+    return try self.import(data: data, password: password)
+  }
+
+  /// Decrypts an encrypted PKCS#8 encrypted private key and builds a complete key pair.
+  ///
+  /// This is the reverse operation of ``export(password:derivedKeyLength:keyDerivationTiming:)``.
+  ///
+  /// - Note: Only supports PKCS#8's PBES2 sceheme using PBKDF2 for key derivation.
+  ///
+  /// - Parameters:
+  ///   - data: Data for exported private key.
+  ///   - password: Password used during key export.
+  /// - Returns: ``SecKeyPair`` for the decrypted & decoded private key.
+  ///
+  public static func `import`(data: Data, password: String) throws -> SecKeyPair {
 
     typealias Nist = iso_itu.country.us.organization.gov.csor.nistAlgorithms
     typealias RSADSI = iso.memberBody.us.rsadsi
@@ -457,7 +473,7 @@ public struct SecKeyPair {
                                                key: importKey,
                                                iv: aesIV)
 
-    return try Self.import(fromData: privateKeyInfoData)
+    return try Self.import(data: privateKeyInfoData)
   }
 
   /// Decodes a PKCS#8 encoded private key and builds a complete key pair.
@@ -466,7 +482,18 @@ public struct SecKeyPair {
   ///   - data: Data for exported private key.
   /// - Returns: ``SecKeyPair`` for the decrypted private key.
   ///
+  @available(*, deprecated, message: "Use import(data:) instead")
   public static func `import`(fromData data: Data) throws -> SecKeyPair {
+    return try self.import(data: data)
+  }
+
+  /// Decodes a PKCS#8 encoded private key and builds a complete key pair.
+  ///
+  /// - Parameters:
+  ///   - data: Data for exported private key.
+  /// - Returns: ``SecKeyPair`` for the decrypted private key.
+  ///
+  public static func `import`(data: Data) throws -> SecKeyPair {
 
     let privateKeyInfo: PrivateKeyInfo
     do {

--- a/Tests/SecKeyPairTests.swift
+++ b/Tests/SecKeyPairTests.swift
@@ -160,9 +160,9 @@ class SecKeyPairTests: XCTestCase {
 
     let exportedKeyData = try rsaKeyPair.export(password: "123")
 
-    let importedKeyPair = try SecKeyPair.import(fromData: exportedKeyData, withPassword: "123")
+    let importedKeyPair = try SecKeyPair.import(data: exportedKeyData, password: "123")
 
-    XCTAssertThrowsError(try SecKeyPair.import(fromData: exportedKeyData, withPassword: "456"))
+    XCTAssertThrowsError(try SecKeyPair.import(data: exportedKeyData, password: "456"))
 
     let plainText = try Random.generate(count: 171)
 
@@ -193,7 +193,7 @@ class SecKeyPairTests: XCTestCase {
 
     let exportedKeyData = try rsaKeyPair.export()
 
-    let importedKeyPair = try SecKeyPair.import(fromData: exportedKeyData)
+    let importedKeyPair = try SecKeyPair.import(data: exportedKeyData)
 
     let plainText = try Random.generate(count: 171)
 
@@ -208,9 +208,9 @@ class SecKeyPairTests: XCTestCase {
 
     let exportedKeyData = try ecKeyPair.export(password: "123")
 
-    _ = try SecKeyPair.import(fromData: exportedKeyData, withPassword: "123")
+    _ = try SecKeyPair.import(data: exportedKeyData, password: "123")
 
-    XCTAssertThrowsError(try SecKeyPair.import(fromData: exportedKeyData, withPassword: "456"))
+    XCTAssertThrowsError(try SecKeyPair.import(data: exportedKeyData, password: "456"))
   }
 
   func testImportExportEC192() throws {
@@ -220,7 +220,7 @@ class SecKeyPairTests: XCTestCase {
         .generate(label: "Test 192 EC Key")
     defer { try? ecKeyPair.delete() }
 
-    XCTAssertThrowsError(try SecKeyPair.import(fromData: ecKeyPair.export())) { error in
+    XCTAssertThrowsError(try SecKeyPair.import(data: ecKeyPair.export())) { error in
       XCTAssertTrue(error is AlgorithmIdentifier.Error)
     }
   }
@@ -232,7 +232,7 @@ class SecKeyPairTests: XCTestCase {
         .generate(label: "Test 256 EC Key")
     defer { try? ecKeyPair.delete() }
 
-    _ = try SecKeyPair.import(fromData: ecKeyPair.export())
+    _ = try SecKeyPair.import(data: ecKeyPair.export())
   }
 
   func testImportExportEC384() throws {
@@ -242,7 +242,7 @@ class SecKeyPairTests: XCTestCase {
         .generate(label: "Test 384 EC Key")
     defer { try? ecKeyPair.delete() }
 
-    _ = try SecKeyPair.import(fromData: ecKeyPair.export())
+    _ = try SecKeyPair.import(data: ecKeyPair.export())
   }
 
   func testImportExportEC521() throws {
@@ -252,7 +252,7 @@ class SecKeyPairTests: XCTestCase {
         .generate(label: "Test 521 EC Key")
     defer { try? ecKeyPair.delete() }
 
-    _ = try SecKeyPair.import(fromData: ecKeyPair.export())
+    _ = try SecKeyPair.import(data: ecKeyPair.export())
   }
 
   func testCodable() throws {

--- a/Tests/SecKeyTests.swift
+++ b/Tests/SecKeyTests.swift
@@ -145,14 +145,14 @@ class SecKeyTests: XCTestCase {
 
     let encodedPublicKey = try keyPair.publicKey.encode()
     let decodedPublicKey = try SecKey.decode(
-      fromData: encodedPublicKey,
+      data: encodedPublicKey,
       type: keyPair.publicKey.type() as CFString,
       class: kSecAttrKeyClassPublic
     )
 
     let encodedPrivateKey = try keyPair.privateKey.encode()
     let decodedPrivateKey = try SecKey.decode(
-      fromData: encodedPrivateKey,
+      data: encodedPrivateKey,
       type: keyPair.publicKey.type() as CFString,
       class: kSecAttrKeyClassPrivate
     )


### PR DESCRIPTION
Deprecates and forwards previous named functions