### PR TITLE
Add accessibility support to `SecKey`, `SecKeyPair`, `SecCertificate` & `SecIdentity`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@
 /TestResults
 
 /ShieldHost/**/xcuserdata/
-/ShieldHost/**/project.xcworkspace/

--- a/ShieldHost/ShieldHost Watch App/ShieldHost Watch App.entitlements
+++ b/ShieldHost/ShieldHost Watch App/ShieldHost Watch App.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/ShieldHost/ShieldHost.xcodeproj/project.pbxproj
+++ b/ShieldHost/ShieldHost.xcodeproj/project.pbxproj
@@ -8,8 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		AA2151F02975D9CF0072F6CA /* ShieldHostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2151EF2975D9CF0072F6CA /* ShieldHostApp.swift */; };
-		AA2151F42975D9D00072F6CA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA2151F32975D9D00072F6CA /* Assets.xcassets */; };
-		AA2151F82975D9D00072F6CA /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA2151F72975D9D00072F6CA /* Preview Assets.xcassets */; };
 		AA2152422975DF5F0072F6CA /* CertificationRequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2152342975DF5F0072F6CA /* CertificationRequestBuilderTests.swift */; };
 		AA2152442975DF5F0072F6CA /* HmacTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2152362975DF5F0072F6CA /* HmacTests.swift */; };
 		AA2152452975DF5F0072F6CA /* OIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2152372975DF5F0072F6CA /* OIDTests.swift */; };
@@ -26,8 +24,6 @@
 		AA2152632975E3600072F6CA /* Shield in Frameworks */ = {isa = PBXBuildFile; productRef = AA2152622975E3600072F6CA /* Shield */; };
 		AA5768A12975E7C300142200 /* ShieldHost Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = AA5768A02975E7C300142200 /* ShieldHost Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		AA5768A62975E7C300142200 /* ShieldHostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5768A52975E7C300142200 /* ShieldHostApp.swift */; };
-		AA5768AA2975E7C400142200 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA5768A92975E7C400142200 /* Assets.xcassets */; };
-		AA5768AD2975E7C400142200 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA5768AC2975E7C400142200 /* Preview Assets.xcassets */; };
 		AA5768E02975E85E00142200 /* Shield in Frameworks */ = {isa = PBXBuildFile; productRef = AA5768DF2975E85E00142200 /* Shield */; };
 		AA5768E12975E87C00142200 /* HmacTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2152362975DF5F0072F6CA /* HmacTests.swift */; };
 		AA5768E22975E87C00142200 /* DistinguishedNameComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2152382975DF5F0072F6CA /* DistinguishedNameComposerTests.swift */; };
@@ -87,10 +83,7 @@
 /* Begin PBXFileReference section */
 		AA2151EC2975D9CF0072F6CA /* ShieldHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ShieldHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA2151EF2975D9CF0072F6CA /* ShieldHostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldHostApp.swift; sourceTree = "<group>"; };
-		AA2151F12975D9CF0072F6CA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		AA2151F32975D9D00072F6CA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AA2151F52975D9D00072F6CA /* ShieldHost.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ShieldHost.entitlements; sourceTree = "<group>"; };
-		AA2151F72975D9D00072F6CA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		AA2151FD2975D9D00072F6CA /* ShieldHostTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShieldHostTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA21521F2975DCA40072F6CA /* Shield */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Shield; path = ..; sourceTree = "<group>"; };
 		AA2152342975DF5F0072F6CA /* CertificationRequestBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CertificationRequestBuilderTests.swift; sourceTree = "<group>"; };
@@ -109,9 +102,6 @@
 		AA57689B2975E7C300142200 /* ShieldHost Watch Container.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ShieldHost Watch Container.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA5768A02975E7C300142200 /* ShieldHost Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ShieldHost Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA5768A52975E7C300142200 /* ShieldHostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldHostApp.swift; sourceTree = "<group>"; };
-		AA5768A72975E7C300142200 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		AA5768A92975E7C400142200 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		AA5768AC2975E7C400142200 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		AA5768B22975E7C400142200 /* ShieldHost Watch AppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ShieldHost Watch AppTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AADD77C629A3E278005D0955 /* CertificateDecoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CertificateDecoderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -178,20 +168,9 @@
 			isa = PBXGroup;
 			children = (
 				AA2151EF2975D9CF0072F6CA /* ShieldHostApp.swift */,
-				AA2151F12975D9CF0072F6CA /* ContentView.swift */,
-				AA2151F32975D9D00072F6CA /* Assets.xcassets */,
 				AA2151F52975D9D00072F6CA /* ShieldHost.entitlements */,
-				AA2151F62975D9D00072F6CA /* Preview Content */,
 			);
 			path = ShieldHost;
-			sourceTree = "<group>";
-		};
-		AA2151F62975D9D00072F6CA /* Preview Content */ = {
-			isa = PBXGroup;
-			children = (
-				AA2151F72975D9D00072F6CA /* Preview Assets.xcassets */,
-			);
-			path = "Preview Content";
 			sourceTree = "<group>";
 		};
 		AA21521E2975DCA40072F6CA /* Packages */ = {
@@ -235,19 +214,8 @@
 			isa = PBXGroup;
 			children = (
 				AA5768A52975E7C300142200 /* ShieldHostApp.swift */,
-				AA5768A72975E7C300142200 /* ContentView.swift */,
-				AA5768A92975E7C400142200 /* Assets.xcassets */,
-				AA5768AB2975E7C400142200 /* Preview Content */,
 			);
 			path = "ShieldHost Watch App";
-			sourceTree = "<group>";
-		};
-		AA5768AB2975E7C400142200 /* Preview Content */ = {
-			isa = PBXGroup;
-			children = (
-				AA5768AC2975E7C400142200 /* Preview Assets.xcassets */,
-			);
-			path = "Preview Content";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -402,8 +370,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AA2151F82975D9D00072F6CA /* Preview Assets.xcassets in Resources */,
-				AA2151F42975D9D00072F6CA /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -425,8 +391,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AA5768AD2975E7C400142200 /* Preview Assets.xcassets in Resources */,
-				AA5768AA2975E7C400142200 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -644,7 +608,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 7J5T2VZQJW;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -681,7 +645,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 7J5T2VZQJW;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;

--- a/ShieldHost/ShieldHost.xcodeproj/project.pbxproj
+++ b/ShieldHost/ShieldHost.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		AA5768A02975E7C300142200 /* ShieldHost Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ShieldHost Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA5768A52975E7C300142200 /* ShieldHostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldHostApp.swift; sourceTree = "<group>"; };
 		AA5768B22975E7C400142200 /* ShieldHost Watch AppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ShieldHost Watch AppTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AAC4C7812ADDCBE600487E0A /* ShieldHost Watch App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "ShieldHost Watch App.entitlements"; sourceTree = "<group>"; };
 		AADD77C629A3E278005D0955 /* CertificateDecoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CertificateDecoderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -213,6 +214,7 @@
 		AA5768A42975E7C300142200 /* ShieldHost Watch App */ = {
 			isa = PBXGroup;
 			children = (
+				AAC4C7812ADDCBE600487E0A /* ShieldHost Watch App.entitlements */,
 				AA5768A52975E7C300142200 /* ShieldHostApp.swift */,
 			);
 			path = "ShieldHost Watch App";
@@ -683,7 +685,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 7J5T2VZQJW;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.outfoxx.ShieldHostTests;
@@ -709,7 +711,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 7J5T2VZQJW;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.outfoxx.ShieldHostTests;
@@ -729,8 +731,10 @@
 		AA5768C52975E7C500142200 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "ShieldHost Watch App/ShieldHost Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7J5T2VZQJW;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = ShieldHost;
@@ -754,8 +758,10 @@
 		AA5768C62975E7C500142200 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "ShieldHost Watch App/ShieldHost Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7J5T2VZQJW;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = ShieldHost;
@@ -783,6 +789,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7J5T2VZQJW;
 				INFOPLIST_KEY_CFBundleDisplayName = ShieldHost;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.outfoxx.ShieldHost;
@@ -798,6 +805,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7J5T2VZQJW;
 				INFOPLIST_KEY_CFBundleDisplayName = ShieldHost;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.outfoxx.ShieldHost;
@@ -815,6 +823,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7J5T2VZQJW;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.outfoxx.ShieldHost-Watch-AppTests";
@@ -834,6 +843,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7J5T2VZQJW;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.outfoxx.ShieldHost-Watch-AppTests";

--- a/ShieldHost/ShieldHost.xcodeproj/project.pbxproj
+++ b/ShieldHost/ShieldHost.xcodeproj/project.pbxproj
@@ -607,7 +607,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShieldHost/ShieldHost.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7J5T2VZQJW;
@@ -644,7 +644,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShieldHost/ShieldHost.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7J5T2VZQJW;

--- a/ShieldHost/ShieldHost.xcodeproj/project.pbxproj
+++ b/ShieldHost/ShieldHost.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		AA5768EC2975E87C00142200 /* DigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA21523D2975DF5F0072F6CA /* DigestTests.swift */; };
 		AA5768ED2975E87C00142200 /* CertificateBuilderECTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA21523A2975DF5F0072F6CA /* CertificateBuilderECTests.swift */; };
 		AA5768EE2975E87C00142200 /* DistinguishedNameParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2152402975DF5F0072F6CA /* DistinguishedNameParserTests.swift */; };
+		AAC4C7862ADDFFAD00487E0A /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC4C7852ADDFFAD00487E0A /* Utils.swift */; };
+		AAC4C7872ADDFFAD00487E0A /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC4C7852ADDFFAD00487E0A /* Utils.swift */; };
 		AADD77C929A3E278005D0955 /* CertificateDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADD77C629A3E278005D0955 /* CertificateDecoderTests.swift */; };
 		AADD77CA29A3E278005D0955 /* CertificateDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADD77C629A3E278005D0955 /* CertificateDecoderTests.swift */; };
 /* End PBXBuildFile section */
@@ -104,6 +106,7 @@
 		AA5768A52975E7C300142200 /* ShieldHostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldHostApp.swift; sourceTree = "<group>"; };
 		AA5768B22975E7C400142200 /* ShieldHost Watch AppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ShieldHost Watch AppTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAC4C7812ADDCBE600487E0A /* ShieldHost Watch App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "ShieldHost Watch App.entitlements"; sourceTree = "<group>"; };
+		AAC4C7852ADDFFAD00487E0A /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		AADD77C629A3E278005D0955 /* CertificateDecoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CertificateDecoderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -199,6 +202,7 @@
 				AA21523F2975DF5F0072F6CA /* SecIdentityTests.swift */,
 				AA2152402975DF5F0072F6CA /* DistinguishedNameParserTests.swift */,
 				AA2152412975DF5F0072F6CA /* SecKeyPairTests.swift */,
+				AAC4C7852ADDFFAD00487E0A /* Utils.swift */,
 			);
 			name = Tests;
 			path = ../Tests;
@@ -423,6 +427,7 @@
 				AA2152452975DF5F0072F6CA /* OIDTests.swift in Sources */,
 				AA2152462975DF5F0072F6CA /* DistinguishedNameComposerTests.swift in Sources */,
 				AA2152492975DF5F0072F6CA /* SecKeyTests.swift in Sources */,
+				AAC4C7862ADDFFAD00487E0A /* Utils.swift in Sources */,
 				AA21524D2975DF5F0072F6CA /* SecIdentityTests.swift in Sources */,
 				AA21524A2975DF5F0072F6CA /* SecCertificateTests.swift in Sources */,
 				AA21524E2975DF5F0072F6CA /* DistinguishedNameParserTests.swift in Sources */,
@@ -452,6 +457,7 @@
 				AA5768EE2975E87C00142200 /* DistinguishedNameParserTests.swift in Sources */,
 				AA5768E72975E87C00142200 /* SecIdentityTests.swift in Sources */,
 				AA5768EC2975E87C00142200 /* DigestTests.swift in Sources */,
+				AAC4C7872ADDFFAD00487E0A /* Utils.swift in Sources */,
 				AA5768E82975E87C00142200 /* CryptorTests.swift in Sources */,
 				AA5768E22975E87C00142200 /* DistinguishedNameComposerTests.swift in Sources */,
 				AA5768ED2975E87C00142200 /* CertificateBuilderECTests.swift in Sources */,
@@ -607,10 +613,10 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShieldHost/ShieldHost.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7J5T2VZQJW;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -644,10 +650,10 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShieldHost/ShieldHost.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7J5T2VZQJW;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -685,7 +691,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7J5T2VZQJW;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.outfoxx.ShieldHostTests;
@@ -711,7 +717,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7J5T2VZQJW;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.outfoxx.ShieldHostTests;
@@ -734,7 +740,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ShieldHost Watch App/ShieldHost Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7J5T2VZQJW;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = ShieldHost;
@@ -761,7 +767,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ShieldHost Watch App/ShieldHost Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7J5T2VZQJW;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = ShieldHost;
@@ -789,7 +795,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7J5T2VZQJW;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_KEY_CFBundleDisplayName = ShieldHost;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.outfoxx.ShieldHost;
@@ -805,7 +811,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7J5T2VZQJW;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_KEY_CFBundleDisplayName = ShieldHost;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.outfoxx.ShieldHost;
@@ -823,7 +829,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7J5T2VZQJW;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.outfoxx.ShieldHost-Watch-AppTests";
@@ -843,7 +849,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7J5T2VZQJW;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.outfoxx.ShieldHost-Watch-AppTests";

--- a/ShieldHost/ShieldHost.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ShieldHost/ShieldHost.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ShieldHost/ShieldHost.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ShieldHost/ShieldHost.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ShieldHost/ShieldHost.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ShieldHost/ShieldHost.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,88 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "BigInt",
+        "repositoryURL": "https://github.com/attaswift/BigInt.git",
+        "state": {
+          "branch": null,
+          "revision": "0ed110f7555c34ff468e72e1686e59721f2b0da6",
+          "version": "5.3.0"
+        }
+      },
+      {
+        "package": "Float16",
+        "repositoryURL": "https://github.com/SusanDoggie/Float16.git",
+        "state": {
+          "branch": null,
+          "revision": "936ae66adccf1c91bcaeeb9c0cddde78a13695c3",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "package": "PotentCodables",
+        "repositoryURL": "https://github.com/outfoxx/PotentCodables.git",
+        "state": {
+          "branch": null,
+          "revision": "0c423eb5fdbbefffd36926430bf99f9f998c0cad",
+          "version": "3.1.1"
+        }
+      },
+      {
+        "package": "Regex",
+        "repositoryURL": "https://github.com/sharplet/Regex.git",
+        "state": {
+          "branch": null,
+          "revision": "76c2b73d4281d77fc3118391877efd1bf972f515",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "package": "swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms",
+        "state": {
+          "branch": null,
+          "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "package": "SwiftDocCPlugin",
+        "repositoryURL": "https://github.com/apple/swift-docc-plugin",
+        "state": {
+          "branch": null,
+          "revision": "10bc670db657d11bdd561e07de30a9041311b2b1",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "SymbolKit",
+        "repositoryURL": "https://github.com/apple/swift-docc-symbolkit",
+        "state": {
+          "branch": null,
+          "revision": "b45d1f2ed151d057b54504d653e0da5552844e34",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
+        "state": {
+          "branch": null,
+          "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",
+          "version": "1.0.2"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/ShieldHost/ShieldHost/ShieldHost.entitlements
+++ b/ShieldHost/ShieldHost/ShieldHost.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>keychain-access-groups</key>
+	<array/>
+</dict>
 </plist>

--- a/ShieldHost/ShieldHost/ShieldHost.entitlements
+++ b/ShieldHost/ShieldHost/ShieldHost.entitlements
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>keychain-access-groups</key>
-	<array/>
-</dict>
+<dict/>
 </plist>

--- a/Sources/ShieldSecurity/AlgorithmIdentifier.swift
+++ b/Sources/ShieldSecurity/AlgorithmIdentifier.swift
@@ -68,7 +68,7 @@ public extension AlgorithmIdentifier {
 
     case .ec:
       let curve: OID
-      switch try publicKey.attributes()[kSecAttrKeySizeInBits as String] as? Int ?? 0 {
+      switch try publicKey.keyAttributes()[kSecAttrKeySizeInBits as String] as? Int ?? 0 {
       case 192:
         // P-192, secp192r1
         curve = iso.memberBody.us.ansix962.curves.prime.prime192v1.oid

--- a/Sources/ShieldSecurity/SecAccessibility.swift
+++ b/Sources/ShieldSecurity/SecAccessibility.swift
@@ -1,0 +1,55 @@
+//
+//  SecAccessibility.swift
+//  Shield
+//
+//  Copyright © 2021 Outfox, inc.
+//
+//
+//  Distributed under the MIT License, See LICENSE for details.
+//
+
+import Security
+
+
+public enum SecAccessibility: Equatable {
+  case `default`
+  case unlocked(afterFirst: Bool, shared: Bool)
+  case passcodeEnabled
+#if ACCESSIBILITY_ALWAYS_ENABLED
+  case always(shared: Bool)
+#endif
+}
+
+
+extension SecAccessibility {
+
+  var attr: Any {
+
+    switch self {
+
+#if ACCESSIBILITY_ALWAYS_ENABLED
+    case .always(shared: true):
+      return kSecAttrAccessibleAlways as String
+
+    case .always(shared: false):
+      return kSecAttrAccessibleAlwaysThisDeviceOnly as String
+#endif
+
+    case .unlocked(afterFirst: true, shared: true):
+      return kSecAttrAccessibleAfterFirstUnlock as String
+
+    case .unlocked(afterFirst: true, shared: false):
+      return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String
+
+    case .unlocked(afterFirst: false, shared: true), .default:
+      return kSecAttrAccessibleWhenUnlocked as String
+
+    case .unlocked(afterFirst: false, shared: false):
+      return kSecAttrAccessibleWhenUnlockedThisDeviceOnly as String
+
+    case .passcodeEnabled:
+      return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly as String
+    }
+  }
+
+}

--- a/Sources/ShieldSecurity/SecCertificate.swift
+++ b/Sources/ShieldSecurity/SecCertificate.swift
@@ -228,7 +228,7 @@ public extension SecCertificate {
     let query: [String: Any] = [
       kSecReturnAttributes as String: true,
       kSecValueRef as String: self,
-      kSecUseDataProtectionKeychain as String: true
+      kSecUseDataProtectionKeychain as String: true,
     ]
 
     var data: CFTypeRef?
@@ -248,7 +248,7 @@ public extension SecCertificate {
       kSecAttrLabel as String: UUID().uuidString,
       kSecValueRef as String: self,
       kSecAttrAccessible as String: accessibility.attr,
-      kSecUseDataProtectionKeychain as String: true
+      kSecUseDataProtectionKeychain as String: true,
     ]
 
     var data: CFTypeRef?
@@ -267,7 +267,7 @@ public extension SecCertificate {
     let query: [String: Any] = [
       kSecClass as String: kSecClassCertificate,
       kSecValueRef as String: self,
-      kSecUseDataProtectionKeychain as String: true
+      kSecUseDataProtectionKeychain as String: true,
     ]
 
     let status = SecItemDelete(query as CFDictionary)

--- a/Sources/ShieldSecurity/SecCertificate.swift
+++ b/Sources/ShieldSecurity/SecCertificate.swift
@@ -29,6 +29,7 @@ public enum SecCertificateError: Int, Error {
   case trustValidationError = 5
   case publicKeyRetrievalFailed = 6
   case parsingFailed = 7
+  case saveDuplicate = 8
 }
 
 
@@ -224,49 +225,52 @@ public extension SecCertificate {
 
   func attributes() throws -> [String: Any] {
 
-    #if os(iOS) || os(watchOS) || os(tvOS)
-
-      let query = [
-        kSecReturnAttributes as String: kCFBooleanTrue!,
-        kSecValueRef as String: self,
-      ] as [String: Any] as CFDictionary
-
-      var data: CFTypeRef?
-
-      let status = SecItemCopyMatching(query as CFDictionary, &data)
-      if status != errSecSuccess {
-        throw SecCertificateError.queryFailed
-      }
-
-    #elseif os(macOS)
-
-      let query: [String: Any] = [
-        kSecReturnAttributes as String: kCFBooleanTrue!,
-        kSecUseItemList as String: [self] as CFArray,
-      ]
-
-      var data: AnyObject?
-
-      let status = SecItemCopyMatching(query as CFDictionary, &data)
-      if status != errSecSuccess {
-        throw SecCertificateError.queryFailed
-      }
-
-    #endif
-
-    return data as! [String: Any] // swiftlint:disable:this force_cast
-  }
-
-  func save() throws {
-
-    let query = [
-      kSecClass as String: kSecClassCertificate,
+    let query: [String: Any] = [
+      kSecReturnAttributes as String: true,
       kSecValueRef as String: self,
-    ] as [String: Any] as CFDictionary
+      kSecUseDataProtectionKeychain as String: true
+    ]
 
     var data: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &data)
 
-    let status = SecItemAdd(query, &data)
+    guard status == errSecSuccess, let attrs = data as? [String: Any] else {
+      throw SecCertificateError.queryFailed
+    }
+
+    return attrs
+  }
+
+  func save(accessibility: SecAccessibility = .default) throws {
+
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassCertificate,
+      kSecAttrLabel as String: UUID().uuidString,
+      kSecValueRef as String: self,
+      kSecAttrAccessible as String: accessibility.attr,
+      kSecUseDataProtectionKeychain as String: true
+    ]
+
+    var data: CFTypeRef?
+    let status = SecItemAdd(query as CFDictionary, &data)
+
+    if status == errSecDuplicateItem {
+      throw SecCertificateError.saveDuplicate
+    }
+    else if status != errSecSuccess {
+      throw SecCertificateError.saveFailed
+    }
+  }
+
+  func delete() throws {
+
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassCertificate,
+      kSecValueRef as String: self,
+      kSecUseDataProtectionKeychain as String: true
+    ]
+
+    let status = SecItemDelete(query as CFDictionary)
 
     if status != errSecSuccess {
       throw SecCertificateError.saveFailed

--- a/Sources/ShieldSecurity/SecKey.swift
+++ b/Sources/ShieldSecurity/SecKey.swift
@@ -204,7 +204,16 @@ public extension SecKey {
 
   func delete() throws {
 
-    try SecKey.delete(persistentReference: try persistentReference())
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassKey,
+      kSecValueRef as String: self,
+      kSecUseDataProtectionKeychain as String: true,
+    ]
+
+    let status = SecItemDelete(query as CFDictionary)
+    if status != errSecSuccess {
+      throw Error.deleteFailed
+    }
   }
 
   static func delete(persistentReference ref: Data) throws {

--- a/Sources/ShieldSecurity/SecKeyPair.swift
+++ b/Sources/ShieldSecurity/SecKeyPair.swift
@@ -141,8 +141,8 @@ public struct SecKeyPair {
         kSecAttrKeyType as String: type.systemValue,
         kSecAttrKeySizeInBits as String: keySize,
         kSecAttrIsPermanent as String: isPermanent,
+        kSecAttrAccessible as String: accessibility.attr,
         kSecUseDataProtectionKeychain as String: true,
-        kSecAttrAccessible as String: accessibility.attr
       ]
 
       if let label = label {

--- a/Sources/ShieldSecurity/SecKeyPair.swift
+++ b/Sources/ShieldSecurity/SecKeyPair.swift
@@ -87,6 +87,8 @@ public struct SecKeyPair {
     public enum Flag {
       /// Generate the key pair in the secure enclave.
       case secureEnclave
+      /// Should the key be saved in the keychain automatically.
+      case permanent
     }
 
     /// Type of key pair to generate ``SecKeyType/ec`` or ``SecKeyType/rsa``.
@@ -120,36 +122,45 @@ public struct SecKeyPair {
     ///
     /// - Parameters:
     ///   - label: User-visible label of the keys (optional).
-    ///   - flat: Flags controlling the generation of the key pair.
+    ///   - flags: Flags controlling the generation of the key pair.
+    ///   - accessibility: Accessibility of the generated key pair.
     /// - Returns: Generated key pair.
     /// - Throws: Errors are thrown when the key generation of persistence to the kaychain fails.
     ///
-    public func generate(label: String? = nil, flags: Set<Flag> = []) throws -> SecKeyPair {
+    public func generate(
+      label: String? = nil,
+      flags: Set<Flag> = [.permanent],
+      accessibility: SecAccessibility = .default
+    ) throws -> SecKeyPair {
       guard let type = type else { fatalError("missing key type") }
       guard let keySize = keySize else { fatalError("missing key size") }
 
-      var attrs: [CFString: Any] = [
-        kSecAttrKeyType: type.systemValue,
-        kSecAttrKeySizeInBits: keySize,
-        kSecAttrIsPermanent: true,
+      let isPermanent = flags.contains(.permanent) || flags.contains(.secureEnclave) || accessibility != .default
+
+      var attrs: [String: Any] = [
+        kSecAttrKeyType as String: type.systemValue,
+        kSecAttrKeySizeInBits as String: keySize,
+        kSecAttrIsPermanent as String: isPermanent,
+        kSecUseDataProtectionKeychain as String: true,
+        kSecAttrAccessible as String: accessibility.attr
       ]
 
       if let label = label {
-        attrs[kSecAttrLabel] = label
+        attrs[kSecAttrLabel as String] = label
       }
 
       if flags.contains(.secureEnclave) {
-        attrs[kSecAttrTokenID] = kSecAttrTokenIDSecureEnclave
+        attrs[kSecAttrTokenID as String] = kSecAttrTokenIDSecureEnclave
       }
 
       var error: Unmanaged<CFError>?
 
       guard let privateKey = SecKeyCreateRandomKey(attrs as CFDictionary, &error) else {
-          throw SecKeyPair.Error.generateFailed
+        throw error?.takeRetainedValue() ?? SecKeyPair.Error.generateFailed
       }
 
       guard let publicKey = SecKeyCopyPublicKey(privateKey) else {
-          throw SecKeyPair.Error.failedToCopyPublicKeyFromPrivateKey
+        throw SecKeyPair.Error.failedToCopyPublicKeyFromPrivateKey
       }
 
       return SecKeyPair(privateKey: privateKey, publicKey: publicKey)
@@ -223,10 +234,10 @@ public struct SecKeyPair {
   ///
   /// - Throws: Errors are thrown if either of the keys could not be saved.
   ///
-  public func save() throws {
+  public func save(accessibility: SecAccessibility = .default) throws {
 
-    try privateKey.save()
-    try publicKey.save()
+    try privateKey.save(accessibility: accessibility)
+    try publicKey.save(accessibility: accessibility)
   }
 
   /// Delete the public and private key from the `Keychain`.
@@ -619,12 +630,12 @@ private extension SecKey {
     return PrivateKeyInfo(version: .zero,
                           privateKeyAlgorithm: .init(algorithm: iso.memberBody.us.ansix962.keyType.ecPublicKey.oid,
                                                      parameters: ASN1.objectIdentifier(curveOID.fields)),
-                                    privateKey: privateKeyData)
+                          privateKey: privateKeyData)
   }
 
   func getECCurveAndNumberSize() throws -> (OID, Int) {
 
-    switch try attributes()[kSecAttrKeySizeInBits as String] as? Int ?? 0 {
+    switch try keyAttributes()[kSecAttrKeySizeInBits as String] as? Int ?? 0 {
     case 192:
       // P-192, secp192r1
       return (iso.memberBody.us.ansix962.curves.prime.prime192v1.oid, 24)

--- a/Tests/CertificateBuilderECTests.swift
+++ b/Tests/CertificateBuilderECTests.swift
@@ -19,7 +19,7 @@ class CertificateBuilderECTests: XCTestCase {
   var keyPair: SecKeyPair!
 
   override func setUpWithError() throws {
-    keyPair = try SecKeyPair.Builder(type: .ec, keySize: 256).generate(label: "Test")
+    keyPair = try generateTestKeyPairChecked(type: .ec, keySize: 256, flags: [])
   }
 
   override func tearDownWithError() throws {

--- a/Tests/CertificateBuilderECTests.swift
+++ b/Tests/CertificateBuilderECTests.swift
@@ -15,19 +15,15 @@ import XCTest
 
 class CertificateBuilderECTests: XCTestCase {
 
-  let outputEnabled = false
-  static var keyPair: SecKeyPair!
+  static let outputEnabled = false
+  var keyPair: SecKeyPair!
 
-  override class func setUp() {
-    // Keys are comparatively slow to generate... so we do it once
-    guard let keyPair = try? SecKeyPair.Builder(type: .ec, keySize: 256).generate(label: "Test") else {
-      return XCTFail("Key pair generation failed")
-    }
-    Self.keyPair = keyPair
+  override func setUpWithError() throws {
+    keyPair = try SecKeyPair.Builder(type: .ec, keySize: 256).generate(label: "Test")
   }
 
-  override class func tearDown() {
-    try? keyPair.delete()
+  override func tearDownWithError() throws {
+    try? keyPair?.delete()
   }
 
   func testBuildVer1() throws {
@@ -38,10 +34,10 @@ class CertificateBuilderECTests: XCTestCase {
     let cert =
       try Certificate.Builder()
         .subject(name: subject)
-        .publicKey(keyPair: Self.keyPair)
+        .publicKey(keyPair: keyPair)
         .issuer(name: issuer)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -59,10 +55,10 @@ class CertificateBuilderECTests: XCTestCase {
     let cert =
       try Certificate.Builder()
         .subject(name: subject, uniqueID: subjectID)
-        .publicKey(keyPair: Self.keyPair)
+        .publicKey(keyPair: keyPair)
         .issuer(name: issuer)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -81,10 +77,10 @@ class CertificateBuilderECTests: XCTestCase {
     let cert =
       try Certificate.Builder()
         .subject(name: subject)
-        .publicKey(keyPair: Self.keyPair)
+        .publicKey(keyPair: keyPair)
         .issuer(name: issuer, uniqueID: issuerID)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -104,10 +100,10 @@ class CertificateBuilderECTests: XCTestCase {
     let cert =
       try Certificate.Builder()
         .subject(name: subject, uniqueID: subjectID)
-        .publicKey(keyPair: Self.keyPair)
+        .publicKey(keyPair: keyPair)
         .issuer(name: issuer, uniqueID: issuerID)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -129,14 +125,14 @@ class CertificateBuilderECTests: XCTestCase {
       try Certificate.Builder()
         .subject(name: subject, uniqueID: subjectID)
         .addSubjectAlternativeNames(names: .dnsName("github.com/outfoxx/Shield"))
-        .publicKey(keyPair: Self.keyPair)
+        .publicKey(keyPair: keyPair)
         .extendedKeyUsage(
           keyPurposes: [iso.org.dod.internet.security.mechanisms.pkix.kp.serverAuth.oid],
           isCritical: false
         )
         .issuer(name: issuer, uniqueID: issuerID)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -156,10 +152,10 @@ class CertificateBuilderECTests: XCTestCase {
       try Certificate.Builder()
         .subject(name: subject)
         .addSubjectAlternativeNames(names: .dnsName("github.com/outfoxx/Shield"))
-        .publicKey(keyPair: Self.keyPair)
+        .publicKey(keyPair: keyPair)
         .issuer(name: issuer)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -179,18 +175,18 @@ class CertificateBuilderECTests: XCTestCase {
       try Certificate.Builder()
         .subject(name: subject, uniqueID: subjectID)
         .addSubjectAlternativeNames(names: .dnsName("github.com/outfoxx/Shield"))
-        .publicKey(keyPair: Self.keyPair)
+        .publicKey(keyPair: keyPair)
         .issuer(name: issuer, uniqueID: issuerID)
         .addIssuerAlternativeNames(names: .dnsName("github.com/outfoxx/Shield/CA"))
         .basicConstraints(ca: true)
         .authorityKeyIdentifier(
-          Digester.digest(Self.keyPair.encodedPublicKey(), using: .sha1),
+          Digester.digest(keyPair.encodedPublicKey(), using: .sha1),
           certIssuer: [.dnsName("github.com/outfoxx/Shield/CA")],
           certSerialNumber: Certificate.Builder.randomSerialNumber()
         )
         .computeSubjectKeyIdentifier()
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -208,8 +204,8 @@ class CertificateBuilderECTests: XCTestCase {
     let csrData =
       try CertificationRequest.Builder()
         .subject(name: NameBuilder().add("Shield Subject", forTypeName: "CN").name)
-        .publicKey(keyPair: Self.keyPair)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .publicKey(keyPair: keyPair)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
         .encoded()
 
     let csr = try ASN1Decoder.decode(CertificationRequest.self, from: csrData)
@@ -222,7 +218,7 @@ class CertificateBuilderECTests: XCTestCase {
         .request(csr)
         .issuer(name: csr.certificationRequestInfo.subject)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -237,12 +233,12 @@ class CertificateBuilderECTests: XCTestCase {
       try CertificationRequest.Builder()
         .subject(name: NameBuilder().add("Shield Subject", forTypeName: "CN").name)
         .addAlternativeNames(names: altNames)
-        .publicKey(keyPair: Self.keyPair, usage: [.dataEncipherment])
+        .publicKey(keyPair: keyPair, usage: [.dataEncipherment])
         .extendedKeyUsage(
           keyPurposes: [iso.org.dod.internet.security.mechanisms.pkix.kp.serverAuth.oid],
           isCritical: false
         )
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
         .encoded()
 
     let csr = try ASN1Decoder.decode(CertificationRequest.self, from: csrData)
@@ -255,7 +251,7 @@ class CertificateBuilderECTests: XCTestCase {
         .request(csr)
         .issuer(name: csr.certificationRequestInfo.subject)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -264,7 +260,7 @@ class CertificateBuilderECTests: XCTestCase {
   }
 
   func output(_ value: Encodable & SchemaSpecified) {
-    guard outputEnabled else { return }
+    guard Self.outputEnabled else { return }
     guard let data = try? value.encoded().base64EncodedString() else { return }
     print(data)
   }

--- a/Tests/CertificateBuilderRSATests.swift
+++ b/Tests/CertificateBuilderRSATests.swift
@@ -15,19 +15,15 @@ import XCTest
 
 class CertificateBuilderRSATests: XCTestCase {
 
-  let outputEnabled = false
-  static var keyPair: SecKeyPair!
+  static let outputEnabled = false
+  var keyPair: SecKeyPair!
 
-  override class func setUp() {
-    // Keys are comparatively slow to generate... so we do it once
-    guard let keyPair = try? SecKeyPair.Builder(type: .rsa, keySize: 2048).generate(label: "Test") else {
-      return XCTFail("Key pair generation failed")
-    }
-    Self.keyPair = keyPair
+  override func setUpWithError() throws {
+    keyPair = try SecKeyPair.Builder(type: .rsa, keySize: 2048).generate(label: "Test")
   }
 
-  override class func tearDown() {
-    try? keyPair.delete()
+  override func tearDownWithError() throws {
+    try? keyPair?.delete()
   }
 
   func testBuildVer1() throws {
@@ -38,10 +34,10 @@ class CertificateBuilderRSATests: XCTestCase {
     let cert =
       try Certificate.Builder()
         .subject(name: subject)
-        .publicKey(keyPair: Self.keyPair)
+        .publicKey(keyPair: keyPair)
         .issuer(name: issuer)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -59,10 +55,10 @@ class CertificateBuilderRSATests: XCTestCase {
     let cert =
       try Certificate.Builder()
         .subject(name: subject, uniqueID: subjectID)
-        .publicKey(keyPair: Self.keyPair)
+        .publicKey(keyPair: keyPair)
         .issuer(name: issuer)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -81,10 +77,10 @@ class CertificateBuilderRSATests: XCTestCase {
     let cert =
       try Certificate.Builder()
         .subject(name: subject)
-        .publicKey(keyPair: Self.keyPair)
+        .publicKey(keyPair: keyPair)
         .issuer(name: issuer, uniqueID: issuerID)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -104,10 +100,10 @@ class CertificateBuilderRSATests: XCTestCase {
     let cert =
       try Certificate.Builder()
         .subject(name: subject, uniqueID: subjectID)
-        .publicKey(keyPair: Self.keyPair)
+        .publicKey(keyPair: keyPair)
         .issuer(name: issuer, uniqueID: issuerID)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -129,14 +125,14 @@ class CertificateBuilderRSATests: XCTestCase {
       try Certificate.Builder()
         .subject(name: subject, uniqueID: subjectID)
         .addSubjectAlternativeNames(names: .dnsName("github.com/outfoxx/Shield"))
-        .publicKey(keyPair: Self.keyPair)
+        .publicKey(keyPair: keyPair)
         .extendedKeyUsage(
           keyPurposes: [iso.org.dod.internet.security.mechanisms.pkix.kp.serverAuth.oid],
           isCritical: false
         )
         .issuer(name: issuer, uniqueID: issuerID)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -156,10 +152,10 @@ class CertificateBuilderRSATests: XCTestCase {
       try Certificate.Builder()
         .subject(name: subject)
         .addSubjectAlternativeNames(names: .dnsName("github.com/outfoxx/Shield"))
-        .publicKey(keyPair: Self.keyPair)
+        .publicKey(keyPair: keyPair)
         .issuer(name: issuer)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -179,18 +175,18 @@ class CertificateBuilderRSATests: XCTestCase {
       try Certificate.Builder()
         .subject(name: subject, uniqueID: subjectID)
         .addSubjectAlternativeNames(names: .dnsName("github.com/outfoxx/Shield"))
-        .publicKey(keyPair: Self.keyPair)
+        .publicKey(keyPair: keyPair)
         .issuer(name: issuer, uniqueID: issuerID)
         .addIssuerAlternativeNames(names: .dnsName("github.com/outfoxx/Shield/CA"))
         .basicConstraints(ca: true)
         .authorityKeyIdentifier(
-          Digester.digest(Self.keyPair.encodedPublicKey(), using: .sha1),
+          Digester.digest(keyPair.encodedPublicKey(), using: .sha1),
           certIssuer: [.dnsName("github.com/outfoxx/Shield/CA")],
           certSerialNumber: Certificate.Builder.randomSerialNumber()
         )
         .computeSubjectKeyIdentifier()
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -208,8 +204,8 @@ class CertificateBuilderRSATests: XCTestCase {
     let csrData =
       try CertificationRequest.Builder()
         .subject(name: NameBuilder().add("Shield Subject", forTypeName: "CN").name)
-        .publicKey(keyPair: Self.keyPair)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .publicKey(keyPair: keyPair)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
         .encoded()
 
     let csr = try ASN1Decoder.decode(CertificationRequest.self, from: csrData)
@@ -222,7 +218,7 @@ class CertificateBuilderRSATests: XCTestCase {
         .request(csr)
         .issuer(name: csr.certificationRequestInfo.subject)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -237,12 +233,12 @@ class CertificateBuilderRSATests: XCTestCase {
       try CertificationRequest.Builder()
         .subject(name: NameBuilder().add("Shield Subject", forTypeName: "CN").name)
         .addAlternativeNames(names: altNames)
-        .publicKey(keyPair: Self.keyPair, usage: [.dataEncipherment])
+        .publicKey(keyPair: keyPair, usage: [.dataEncipherment])
         .extendedKeyUsage(
           keyPurposes: [iso.org.dod.internet.security.mechanisms.pkix.kp.serverAuth.oid],
           isCritical: false
         )
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
         .encoded()
 
     let csr = try ASN1Decoder.decode(CertificationRequest.self, from: csrData)
@@ -255,7 +251,7 @@ class CertificateBuilderRSATests: XCTestCase {
         .request(csr)
         .issuer(name: csr.certificationRequestInfo.subject)
         .valid(for: 86400 * 365)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(cert)
 
@@ -264,7 +260,7 @@ class CertificateBuilderRSATests: XCTestCase {
   }
 
   func output(_ value: Encodable & SchemaSpecified) {
-    guard outputEnabled else { return }
+    guard Self.outputEnabled else { return }
     guard let data = try? value.encoded().base64EncodedString() else { return }
     print(data)
   }

--- a/Tests/CertificateBuilderRSATests.swift
+++ b/Tests/CertificateBuilderRSATests.swift
@@ -19,7 +19,7 @@ class CertificateBuilderRSATests: XCTestCase {
   var keyPair: SecKeyPair!
 
   override func setUpWithError() throws {
-    keyPair = try SecKeyPair.Builder(type: .rsa, keySize: 2048).generate(label: "Test")
+    keyPair = try generateTestKeyPairChecked(type: .rsa, keySize: 2048, flags: [])
   }
 
   override func tearDownWithError() throws {

--- a/Tests/CertificationRequestBuilderTests.swift
+++ b/Tests/CertificationRequestBuilderTests.swift
@@ -19,12 +19,11 @@ class CertificationRequestBuilderTests: XCTestCase {
   var keyPair: SecKeyPair!
 
   override func setUpWithError() throws {
-    // Keys are comparatively slow to generate... so we do it once
-    keyPair = try SecKeyPair.Builder(type: .rsa, keySize: 2048).generate(label: "Test")
+    keyPair = try generateTestKeyPairChecked(type: .rsa, keySize: 2048, flags: [])
   }
 
   override func tearDownWithError() throws {
-    try keyPair?.delete()
+    try? keyPair?.delete()
   }
 
   func testBuildParse() throws {

--- a/Tests/CertificationRequestBuilderTests.swift
+++ b/Tests/CertificationRequestBuilderTests.swift
@@ -16,18 +16,15 @@ import XCTest
 class CertificationRequestBuilderTests: XCTestCase {
 
   static let outputEnabled = false
-  static var keyPair: SecKeyPair!
+  var keyPair: SecKeyPair!
 
-  override class func setUp() {
+  override func setUpWithError() throws {
     // Keys are comparatively slow to generate... so we do it once
-    guard let keyPair = try? SecKeyPair.Builder(type: .rsa, keySize: 2048).generate(label: "Test") else {
-      return XCTFail("Key pair generation failed")
-    }
-    Self.keyPair = keyPair
+    keyPair = try SecKeyPair.Builder(type: .rsa, keySize: 2048).generate(label: "Test")
   }
 
-  override class func tearDown() {
-    try? keyPair.delete()
+  override func tearDownWithError() throws {
+    try keyPair?.delete()
   }
 
   func testBuildParse() throws {
@@ -36,9 +33,9 @@ class CertificationRequestBuilderTests: XCTestCase {
     let csr =
       try CertificationRequest.Builder()
         .subject(name: NameBuilder().add("Outfox Signing", forTypeName: "CN").name)
-        .publicKey(keyPair: Self.keyPair, usage: [.keyCertSign, .cRLSign])
+        .publicKey(keyPair: keyPair, usage: [.keyCertSign, .cRLSign])
         .extendedKeyUsage(keyPurposes: [keyPurpose.clientAuth.oid, keyPurpose.serverAuth.oid], isCritical: true)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(csr)
 
@@ -73,9 +70,9 @@ class CertificationRequestBuilderTests: XCTestCase {
       try CertificationRequest.Builder()
         .subject(name: NameBuilder().add("Outfox Signing", forTypeName: "CN").name)
         .addAlternativeNames(names: sans)
-        .publicKey(keyPair: Self.keyPair, usage: [.keyCertSign, .cRLSign])
+        .publicKey(keyPair: keyPair, usage: [.keyCertSign, .cRLSign])
         .extendedKeyUsage(keyPurposes: [keyPurpose.clientAuth.oid, keyPurpose.serverAuth.oid], isCritical: true)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
 
     output(csr)
 

--- a/Tests/SecCertificateTests.swift
+++ b/Tests/SecCertificateTests.swift
@@ -14,18 +14,14 @@ import XCTest
 class SecCertificateTests: XCTestCase {
 
   static let outputEnabled = false
-  static var keyPair: SecKeyPair!
+  var keyPair: SecKeyPair!
 
-  override class func setUp() {
-    // Keys are comparatively slow to generate... so we do it once
-    guard let keyPair = try? SecKeyPair.Builder(type: .rsa, keySize: 2048).generate(label: "Test") else {
-      return XCTFail("Key pair generation failed")
-    }
-    Self.keyPair = keyPair
+  override func setUpWithError() throws {
+    keyPair = try SecKeyPair.Builder(type: .rsa, keySize: 2048).generate(label: "Test")
   }
 
-  override class func tearDown() {
-    try? keyPair.delete()
+  override func tearDownWithError() throws {
+    try? keyPair?.delete()
   }
 
   func testSaveAcccessibilityUnlockedNotShared() throws {
@@ -43,9 +39,9 @@ class SecCertificateTests: XCTestCase {
       try Certificate.Builder()
         .subject(name: subjectName)
         .issuer(name: issuerName)
-        .publicKey(keyPair: Self.keyPair, usage: [.keyCertSign, .cRLSign])
+        .publicKey(keyPair: keyPair, usage: [.keyCertSign, .cRLSign])
         .valid(for: 86400 * 5)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
         .encoded()
 
     output(certData)
@@ -75,9 +71,9 @@ class SecCertificateTests: XCTestCase {
       try Certificate.Builder()
         .subject(name: subjectName)
         .issuer(name: issuerName)
-        .publicKey(keyPair: Self.keyPair, usage: [.keyCertSign, .cRLSign])
+        .publicKey(keyPair: keyPair, usage: [.keyCertSign, .cRLSign])
         .valid(for: 86400 * 5)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
         .encoded()
 
     output(certData)
@@ -103,16 +99,16 @@ class SecCertificateTests: XCTestCase {
       try Certificate.Builder()
         .subject(name: subjectName)
         .issuer(name: issuerName)
-        .publicKey(keyPair: Self.keyPair, usage: [.keyCertSign, .cRLSign])
+        .publicKey(keyPair: keyPair, usage: [.keyCertSign, .cRLSign])
         .valid(for: 86400 * 5)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
         .encoded()
 
     output(certData)
 
     let cert = try SecCertificate.from(data: certData)
 
-    XCTAssertEqual(try cert.publicKey?.encode(), try Self.keyPair.publicKey.encode())
+    XCTAssertEqual(try cert.publicKey?.encode(), try keyPair.publicKey.encode())
   }
 
   func testPEM() throws {
@@ -130,9 +126,9 @@ class SecCertificateTests: XCTestCase {
       try Certificate.Builder()
         .subject(name: subjectName)
         .issuer(name: issuerName)
-        .publicKey(keyPair: Self.keyPair, usage: [.keyCertSign, .cRLSign])
+        .publicKey(keyPair: keyPair, usage: [.keyCertSign, .cRLSign])
         .valid(for: 86400 * 5)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
         .encoded()
 
     let certSec = try SecCertificate.from(data: certData)
@@ -156,9 +152,9 @@ class SecCertificateTests: XCTestCase {
       try Certificate.Builder()
         .subject(name: subjectName)
         .issuer(name: issuerName)
-        .publicKey(keyPair: Self.keyPair, usage: [.keyCertSign, .cRLSign])
+        .publicKey(keyPair: keyPair, usage: [.keyCertSign, .cRLSign])
         .valid(for: 86400 * 5)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
         .encoded()
 
     let certSec = try SecCertificate.from(data: certData)
@@ -172,19 +168,19 @@ class SecCertificateTests: XCTestCase {
     let rootName = try NameBuilder().add("Unit Testing Root", forTypeName: "CN").name
     let rootID = try Random.generate(count: 10)
     let rootSerialNumber = try Certificate.Builder.randomSerialNumber()
-    let rootKeyHash = try Digester.digest(Self.keyPair.encodedPublicKey(), using: .sha1)
+    let rootKeyHash = try Digester.digest(keyPair.encodedPublicKey(), using: .sha1)
     let rootCertData =
     try Certificate.Builder()
       .serialNumber(rootSerialNumber)
       .subject(name: rootName, uniqueID: rootID)
       .subjectAlternativeNames(names: .dnsName("io.outfoxx.shield.tests.ca"))
-      .publicKey(keyPair: Self.keyPair, usage: [.keyCertSign, .cRLSign])
+      .publicKey(keyPair: keyPair, usage: [.keyCertSign, .cRLSign])
       .subjectKeyIdentifier(rootKeyHash)
       .issuer(name: rootName)
       .issuerAlternativeNames(names: .dnsName("io.outfoxx.shield.tests.ca"))
       .basicConstraints(ca: true)
       .valid(for: 86400 * 5)
-      .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+      .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
       .encoded()
     output(rootCertData)
 
@@ -207,7 +203,7 @@ class SecCertificateTests: XCTestCase {
       .issuerAlternativeNames(names: .dnsName("io.outfoxx.shield.tests.ca"))
       .authorityKeyIdentifier(rootKeyHash, certIssuer: [.directoryName(rootName)], certSerialNumber: rootSerialNumber)
       .valid(for: 86400 * 5)
-      .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+      .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
       .encoded()
     output(certData)
 
@@ -238,19 +234,19 @@ class SecCertificateTests: XCTestCase {
     let rootName = try NameBuilder().add("Unit Testing Root", forTypeName: "CN").name
     let rootID = try Random.generate(count: 10)
     let rootSerialNumber = try Certificate.Builder.randomSerialNumber()
-    let rootKeyHash = try Digester.digest(Self.keyPair.encodedPublicKey(), using: .sha1)
+    let rootKeyHash = try Digester.digest(keyPair.encodedPublicKey(), using: .sha1)
     let rootCertData =
     try Certificate.Builder()
       .serialNumber(rootSerialNumber)
       .subject(name: rootName, uniqueID: rootID)
       .subjectAlternativeNames(names: .dnsName("io.outfoxx.shield.tests.ca"))
-      .publicKey(keyPair: Self.keyPair, usage: [.keyCertSign, .cRLSign])
+      .publicKey(keyPair: keyPair, usage: [.keyCertSign, .cRLSign])
       .subjectKeyIdentifier(rootKeyHash)
       .issuer(name: rootName)
       .issuerAlternativeNames(names: .dnsName("io.outfoxx.shield.tests.ca"))
       .basicConstraints(ca: true)
       .valid(for: 86400 * 5)
-      .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+      .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
       .encoded()
     output(rootCertData)
 
@@ -273,7 +269,7 @@ class SecCertificateTests: XCTestCase {
       .issuerAlternativeNames(names: .dnsName("io.outfoxx.shield.tests.ca"))
       .authorityKeyIdentifier(rootKeyHash, certIssuer: [.directoryName(rootName)], certSerialNumber: rootSerialNumber)
       .valid(for: 86400 * 5)
-      .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+      .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
       .encoded()
     output(certData)
 
@@ -294,9 +290,9 @@ class SecCertificateTests: XCTestCase {
       try Certificate.Builder()
         .subject(name: rootName)
         .issuer(name: rootName)
-        .publicKey(keyPair: Self.keyPair, usage: [.keyCertSign])
+        .publicKey(keyPair: keyPair, usage: [.keyCertSign])
         .valid(for: 86400 * 5)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
         .encoded()
     )
 
@@ -342,9 +338,9 @@ class SecCertificateTests: XCTestCase {
       try Certificate.Builder()
         .subject(name: rootName)
         .issuer(name: rootName)
-        .publicKey(keyPair: Self.keyPair, usage: [.keyCertSign])
+        .publicKey(keyPair: keyPair, usage: [.keyCertSign])
         .valid(for: 86400 * 5)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
         .encoded()
     )
 
@@ -359,7 +355,7 @@ class SecCertificateTests: XCTestCase {
         .issuer(name: rootName)
         .publicKey(keyPair: certKeyPair, usage: [.keyEncipherment])
         .valid(for: 86400 * 5)
-        .build(signingKey: Self.keyPair.privateKey, digestAlgorithm: .sha256)
+        .build(signingKey: keyPair.privateKey, digestAlgorithm: .sha256)
         .encoded()
     )
 

--- a/Tests/SecKeyTests.swift
+++ b/Tests/SecKeyTests.swift
@@ -14,9 +14,20 @@ import XCTest
 
 class SecKeyTests: XCTestCase {
 
+  func testAttributesFailForNonPermanentKeys() throws {
+    let keyPair = try generateTestKeyPairChecked(type: .ec, keySize: 256, flags: [])
+    defer { try? keyPair.delete() }
+
+    XCTAssertNoThrow(try keyPair.privateKey.keyAttributes())
+    XCTAssertThrowsError(try keyPair.privateKey.attributes())
+  }
+
   func testSaveAcccessibilityUnlocked() throws {
-    let keyPair = try SecKeyPair.Builder(type: .ec, keySize: 256)
-      .generate(label: "Test", flags: [])
+    // Check entitlement
+    try generateTestKeyPairChecked(type: .ec, keySize: 256).delete()
+
+    let keyPair = try generateTestKeyPairChecked(type: .ec, keySize: 256, flags: [])
+    defer { try? keyPair.delete() }
 
     try keyPair.save(accessibility: .unlocked(afterFirst: false, shared: true))
 
@@ -25,8 +36,9 @@ class SecKeyTests: XCTestCase {
   }
 
   func testGenerateAccessibilityUnlocked() throws {
-    let keyPair = try SecKeyPair.Builder(type: .ec, keySize: 256)
-      .generate(label: "Test", accessibility: .unlocked(afterFirst: false, shared: true))
+    let keyPair = try generateTestKeyPairChecked(type: .ec,
+                                                 keySize: 256,
+                                                 accessibility: .unlocked(afterFirst: false, shared: true))
     defer { try? keyPair.delete() }
 
     let attrs = try keyPair.privateKey.attributes()
@@ -34,8 +46,9 @@ class SecKeyTests: XCTestCase {
   }
 
   func testGenerateAccessibilityAfterFirstUnlockNotShared() throws {
-    let keyPair = try SecKeyPair.Builder(type: .ec, keySize: 256)
-      .generate(label: "Test", accessibility: .unlocked(afterFirst: true, shared: false))
+    let keyPair = try generateTestKeyPairChecked(type: .ec,
+                                                 keySize: 256,
+                                                 accessibility: .unlocked(afterFirst: true, shared: false))
     defer { try? keyPair.delete() }
 
     let attrs = try keyPair.privateKey.attributes()
@@ -43,7 +56,7 @@ class SecKeyTests: XCTestCase {
   }
 
   func testRSA() throws {
-    let keyPair = try SecKeyPair.Builder(type: .rsa, keySize: 2048).generate(label: "Test")
+    let keyPair = try generateTestKeyPairChecked(type: .rsa, keySize: 2048, flags: [])
     defer { try? keyPair.delete() }
 
     print("Checking: RSA Encrypt/Decrypt")
@@ -65,7 +78,8 @@ class SecKeyTests: XCTestCase {
   }
 
   func testEC() throws {
-    let keyPair = try SecKeyPair.Builder(type: .ec, keySize: 256).generate(label: "Test")
+    let keyPair = try generateTestKeyPairChecked(type: .ec, keySize: 256, flags: [])
+    defer { try? keyPair.delete() }
 
     print("Checking: EC Encrypt/Decrypt")
     testFailedEncryptError(keyPair)
@@ -87,7 +101,7 @@ class SecKeyTests: XCTestCase {
   func testECGeneration() throws {
     try [192, 256, 384, 521].forEach { keySize in
 
-      let keyPair = try SecKeyPair.Builder(type: .ec, keySize: keySize).generate(label: "Test")
+      let keyPair = try generateTestKeyPairChecked(type: .ec, keySize: keySize, flags: [])
       defer { try? keyPair.delete() }
 
       _ = try AlgorithmIdentifier(publicKey: keyPair.publicKey)

--- a/Tests/SecKeyTests.swift
+++ b/Tests/SecKeyTests.swift
@@ -8,10 +8,39 @@
 //  Distributed under the MIT License, See LICENSE for details.
 //
 
+import Security
 @testable import Shield
 import XCTest
 
 class SecKeyTests: XCTestCase {
+
+  func testSaveAcccessibilityUnlocked() throws {
+    let keyPair = try SecKeyPair.Builder(type: .ec, keySize: 256)
+      .generate(label: "Test", flags: [])
+
+    try keyPair.save(accessibility: .unlocked(afterFirst: false, shared: true))
+
+    let attrs = try keyPair.privateKey.attributes()
+    XCTAssertEqual(attrs[kSecAttrAccessible as String] as? String, kSecAttrAccessibleWhenUnlocked as String)
+  }
+
+  func testGenerateAccessibilityUnlocked() throws {
+    let keyPair = try SecKeyPair.Builder(type: .ec, keySize: 256)
+      .generate(label: "Test", accessibility: .unlocked(afterFirst: false, shared: true))
+    defer { try? keyPair.delete() }
+
+    let attrs = try keyPair.privateKey.attributes()
+    XCTAssertEqual(attrs[kSecAttrAccessible as String] as? String, kSecAttrAccessibleWhenUnlocked as String)
+  }
+
+  func testGenerateAccessibilityAfterFirstUnlockNotShared() throws {
+    let keyPair = try SecKeyPair.Builder(type: .ec, keySize: 256)
+      .generate(label: "Test", accessibility: .unlocked(afterFirst: true, shared: false))
+    defer { try? keyPair.delete() }
+
+    let attrs = try keyPair.privateKey.attributes()
+    XCTAssertEqual(attrs[kSecAttrAccessible as String] as? String, kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String)
+  }
 
   func testRSA() throws {
     let keyPair = try SecKeyPair.Builder(type: .rsa, keySize: 2048).generate(label: "Test")

--- a/Tests/Utils.swift
+++ b/Tests/Utils.swift
@@ -1,0 +1,45 @@
+//
+//  Utils.swift
+//  Shield
+//
+//  Copyright © 2021 Outfox, inc.
+//
+//
+//  Distributed under the MIT License, See LICENSE for details.
+//
+
+import Shield
+import Security
+import XCTest
+
+func generateTestKeyPairChecked(
+  type: SecKeyType,
+  keySize: Int,
+  flags: Set<SecKeyPair.Builder.Flag> = [.permanent],
+  accessibility: SecAccessibility = .default
+) throws -> SecKeyPair {
+  let label: String = [
+    "Test",
+    flags.contains(.secureEnclave) ? "Secure Enclave" : nil,
+    type == .ec ? "EC" : "RSA",
+    "Key Pair",
+  ].compactMap { $0 }.joined(separator: " ")
+
+  do {
+    return try SecKeyPair.Builder(type: type, keySize: keySize).generate(label: label,
+                                                                         flags: flags,
+                                                                         accessibility: accessibility)
+  }
+  catch let error where isEntitlementMissingError(error) {
+    #if os(macOS)
+    throw XCTSkip("Missing keychain entitlement")
+    #else
+    throw error
+    #endif
+  }
+}
+
+func isEntitlementMissingError(_ error: Error) -> Bool {
+  let error = error as NSError
+  return error.domain == NSOSStatusErrorDomain && error.code == -34018
+}


### PR DESCRIPTION
Allows selecting accessibility (i.e. `kSecAttrAccessible`) when generating or saving items.

As a requirement we add `kSecUseDataProtectionKeychain` to keychain requests. This has the benefit of normalizing keychain access across macOS & iOS, tvOS, watchOS); allowing the removal of the last usage of `#if os(macOS)/#endif` when accessing the keychain.

`SecKey.attributes()` now retrieves _all_ attributes from using `SecItemCopyMatching` instead of  `SecKeyCopyAttributes`; this is backward compatible with previous functionality with _more_ attributes. `SecKey.keyAttributes()` can be used to get previous _smaller_ list of attributes (which may also be faster).