### PR TITLE
Marked KeyUsage as Sendable

### DIFF
--- a/Sources/ShieldX509/ExtensionKeyUsage.swift
+++ b/Sources/ShieldX509/ExtensionKeyUsage.swift
@@ -13,7 +13,7 @@ import PotentASN1
 import ShieldOID
 
 
-public struct KeyUsage: OptionSet, Equatable, Hashable, Codable, CriticalExtensionValue {
+public struct KeyUsage: OptionSet, Equatable, Hashable, Codable, CriticalExtensionValue, Sendable {
 
   public static var extensionID = iso_itu.ds.certificateExtension.keyUsage.oid
   public static var asn1Schema = Schemas.keyUsageExtension


### PR DESCRIPTION
Silences a warning about `digitalSignature` and others being non-sendable when using Shield in a strict Swift concurrency setting.